### PR TITLE
Add Docker instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git*
+docs
+Dockerfile
+.Dockerfile.swp
+README.adoc
+dist
+node_modules
+github-icon.png

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:16-alpine
+
+WORKDIR /timer
+COPY . .
+RUN npm install
+RUN npm run build
+
+FROM nginx:1.21-alpine
+
+COPY --from=0 /timer/dist /usr/share/nginx/html
+


### PR DESCRIPTION
Adding the ability to create an OCI container using a `Dockerfile`.

Instructions:

    # build
    docker build -t qoomon/time-timer-webapp:latest .
    # run
    docker run --rm -p 8080:80 qoomon/time-timer-webapp
    # open in browser
    xdg-open "http://localhost:8080"